### PR TITLE
Update handling.js

### DIFF
--- a/src/handling.js
+++ b/src/handling.js
@@ -51,7 +51,7 @@ Hooks.once("ready", () => {
     })
     .then(async (json) => {
       if ((json.version ?? 0) > cur && isGM()) {
-        ui.notifications.warn(`Module has new rules, please sync it`);
+        ui.notifications.warn(`pf2e-automations has new rules, please sync it`);
       }
     });
 });


### PR DESCRIPTION
Warning still does not explain what is throwing the error, which is very confusing. Adding the module name to provide clarity when the error shows up for GMs.