### PR TITLE
Add compatibility with PF2e Toolbelt module

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,11 @@ async function processMessage(message: ChatMessage) {
 Hooks.on("createChatMessage", processMessage);
 Hooks.on(`${moduleName}.processMessage`, processMessage);
 
+
+Hooks.on("pf2e-toolbelt.rollSave", (data: any) => {
+    processMessage(data?.rollMessage);
+});
+
 Hooks.on("renderChatMessageHTML", async (message: ChatMessage, html: HTMLElement) => {
     moduleHooks.renderChatMessage.forEach(h => {
         h.listen(message, html)


### PR DESCRIPTION
The module [PF2e Toolbelt](https://github.com/reonZ/pf2e-toolbelt) has a `Target Helper` feature that can prevent saving throws from being created as their own chat messages. It offers [hooks](https://github.com/reonZ/pf2e-toolbelt/wiki/Target-Helper#hooks) that allow these saving throws to still be processed by other modules.

With this change, clicking an embedded saving throw button from the `Target Helper` feature of PF2e Toolbelt will automatically run rules from Pf2e Automations, with no additional chat card being created for the the saving throw.

Note: Rerolls through the PF2e Toolbelt button still won't run Pf2e Automations rules. Fixing this would require a custom listener for the `pf2e-toolbelt.rerollSave` hook, instead of using `HandleRuleMessage.listen`.